### PR TITLE
Fix description toggle in AI word game

### DIFF
--- a/ai-word-game.html
+++ b/ai-word-game.html
@@ -314,7 +314,9 @@
     }
 
     function showDescription() {
-      descriptionText.style.display = descriptionText.style.display === 'none' ? 'block' : 'none';
+      // 기본 CSS에서 display가 'none'이므로 ''(빈 값)과 'none' 모두를 체크
+      const cur = descriptionText.style.display;
+      descriptionText.style.display = (cur === 'none' || cur === '') ? 'block' : 'none';
     }
 
     function loadProblem() {


### PR DESCRIPTION
## Summary
- fix description toggle so '게임 설명 보기' works on the first click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684135a753dc832888cb39a6ddc51979